### PR TITLE
Move domain to title position for default theme

### DIFF
--- a/LinkPreview.astro
+++ b/LinkPreview.astro
@@ -48,8 +48,10 @@ const placeholderSvg = `<svg class="lp__placeholder" viewBox="0 0 1200 630" role
 
       {theme === "x" && <div class="lp__domain--overlay">{domain}</div>}
       <div class="lp__body">
-        {theme !== "x" && <small class="lp__domain">{domain}</small>}
-        <h4 class="lp__title">{title}</h4>
+        {theme !== "x" && theme !== "default" && (
+          <small class="lp__domain">{domain}</small>
+        )}
+        <h4 class="lp__title">{theme === "default" ? domain : title}</h4>
         {description && <p class="lp__desc">{description}</p>}
 
         {


### PR DESCRIPTION
## Summary
- swap out the title for the domain when using the `default` theme
- hide the top-domain element for the `default` theme

## Testing
- `npm pack` *(fails: no test commands)*

------
https://chatgpt.com/codex/tasks/task_e_686aed485008832a8ac4f8e2231571ca