### PR TITLE
Move domain to title position for default theme

### DIFF
--- a/LinkPreview.astro
+++ b/LinkPreview.astro
@@ -49,7 +49,7 @@ const placeholderSvg = `<svg class="lp__placeholder" viewBox="0 0 1200 630" role
       {theme === "x" && <div class="lp__domain--overlay">{domain}</div>}
       <div class="lp__body">
         {theme !== "x" && <small class="lp__domain">{domain}</small>}
-        <h4 class="lp__title">{title}</h4>
+        <h4 class="lp__title">{theme === "default" ? domain : title}</h4>
         {description && <p class="lp__desc">{description}</p>}
 
         {
@@ -196,6 +196,9 @@ const placeholderSvg = `<svg class="lp__placeholder" viewBox="0 0 1200 630" role
       .lp--default .lp__favicon {
         width: 0.75rem;
         height: 0.75rem;
+      }
+      .lp--default .lp__domain {
+        display: none;
       }
 
       /* ===== small ===== */


### PR DESCRIPTION
## Summary
- swap out the title for the domain when using the `default` theme
- keep domain element in DOM and hide it for the `default` theme so layout stays consistent

## Testing
- `npm pack`


------
https://chatgpt.com/codex/tasks/task_e_686aed485008832a8ac4f8e2231571ca